### PR TITLE
prevent unhandled exception on empty line in file /proc/$pid/status

### DIFF
--- a/iotop/data.py
+++ b/iotop/data.py
@@ -196,9 +196,11 @@ def find_uids(options):
 def parse_proc_pid_status(pid):
     result_dict = {}
     try:
+        sep = ':\t'
         for line in open('/proc/%d/status' % pid):
-            key, value = line.split(':\t', 1)
-            result_dict[key] = value.strip()
+            if sep in line:
+                key, value = line.split(sep, 1)
+                result_dict[key] = value.strip()
     except IOError:
         pass  # No such process
     return result_dict


### PR DESCRIPTION
On Ubuntu 16.04(r-1) iotop terminated due to an uncaught exception:
```
Traceback (most recent call last):
  File "/usr/sbin/iotop", line 17, in <module>
    main()
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 620, in main
    main_loop()
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 610, in <lambda>
    main_loop = lambda: run_iotop(options)
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 508, in run_iotop
    return curses.wrapper(run_iotop_window, options)
  File "/usr/lib/python2.7/curses/wrapper.py", line 43, in wrapper
    return func(stdscr, *args, **kwds)
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 501, in run_iotop_window
    ui.run()
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 155, in run
    self.process_list.duration)
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 434, in refresh_display
    lines = self.get_data()
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 415, in get_data
    return list(map(format, processes))
  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 388, in format
    cmdline = p.get_cmdline()
  File "/usr/lib/python2.7/dist-packages/iotop/data.py", line 292, in get_cmdline
    proc_status = parse_proc_pid_status(self.pid)
  File "/usr/lib/python2.7/dist-packages/iotop/data.py", line 196, in parse_proc_pid_status
    key, value = line.split(':\t', 1)
ValueError: need more than 1 value to unpack
```

If file /proc/$pid/status contains empty string,
an exception ValueError raised because string.split() returns list of
strings with one item (but required two).
Now, line is checked for containing separator and this check avoids an exception raising.