### PR TITLE
Fix two code exceptions which didn't allow me to start iotop

### DIFF
--- a/iotop/data.py
+++ b/iotop/data.py
@@ -455,7 +455,7 @@ class ProcessList(DumpableObject):
 
         total_read_and_write = self.update_process_counts()
 
-        for pid, process in self.processes.items():
+        for pid, process in self.processes.copy().items():
             if not process.update_stats():
                 del self.processes[pid]
 

--- a/iotop/data.py
+++ b/iotop/data.py
@@ -197,7 +197,8 @@ def parse_proc_pid_status(pid):
     result_dict = {}
     try:
         sep = ':\t'
-        for line in open('/proc/%d/status' % pid):
+        for line in open('/proc/%d/status' % pid, encoding='ascii',
+                         errors='backslashreplace'):
             if sep in line:
                 key, value = line.split(sep, 1)
                 result_dict[key] = value.strip()


### PR DESCRIPTION
On a production machine, I couldn't start `iotop`. This pull request
should fix both issues which I encountered.
